### PR TITLE
Add events system

### DIFF
--- a/.github/workflows/update-events.yaml
+++ b/.github/workflows/update-events.yaml
@@ -1,0 +1,43 @@
+name: Update events table
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'events/**'
+      - 'events/scripts/update_events.py'
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+
+      - name: Run updater
+        run: python events/scripts/update_events.py
+
+      - name: Commit changes
+        run: |
+          if ! git diff --quiet; then
+            git config user.name "github-actions"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "auto: update events table and archive old events"
+            git push
+          else
+            echo "No changes to commit"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Contact us early in your project to discuss requirements or explore automation a
 
 ## Events
 
-The table below lists upcoming and recent events. It is automatically generated from individual event files in the `events/` folder. To add an event follow the instructions in `events/add-an-event.md`. A GitHub Action will update this table automatically. 
+The table below lists upcoming and recent events. It is automatically generated from individual event files in the `events/` folder. To add an event follow the instructions in `events/add-an-event.md`. A GitHub Action will update this table automatically.
+
+<!-- EVENTS:START -->
+...
+<!-- EVENTS:END -->
 
 ## Contacts
 

--- a/events/2025-11-05-Biosciences-Comp-Training.yaml
+++ b/events/2025-11-05-Biosciences-Comp-Training.yaml
@@ -1,0 +1,21 @@
+# Copy this file to events/YYYY-MM-DD-short-title.yaml and edit.
+id: Biosciences Comp Training (Capacity Reached)
+
+# Required
+title: Biosciences Computational Training
+start: 2025-11-05
+timezone: Europe/London
+location: UCL Bloomsbury Campus
+
+
+# Optional but recommended
+end:
+organiser: James Gilbert
+audience: Biosciences researchers
+link: https://ucl-biosciences.github.io/2025-11-03-Biosciences/
+registration_link:
+contact: james.d.gilbert@ucl.ac.uk
+
+# Short markdown description
+summary: |
+Short abstract or blurb in one or two sentences.

--- a/events/add-an-event.md
+++ b/events/add-an-event.md
@@ -1,0 +1,13 @@
+# Add an event
+1. Copy `events/template.yaml` to `events/YYYY-MM-DD-short-title.yaml`.
+2. Fill in the required fields.
+4. Open a pull request. Maintainers will merge and the table in the README will update automatically.
+
+## Naming rules
+- File name must start with the event date: `YYYY-MM-DD`.
+- Use lowercase and hyphens only.
+
+## Field notes
+- `start` and `end` use 24-hour time, e.g. `2025-11-15 12:30`.
+- `timezone` must be an IANA zone like `Europe/London`.
+- `summary` supports basic Markdown.

--- a/events/scripts/update_events.py
+++ b/events/scripts/update_events.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import re
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EVENTS_DIR = REPO_ROOT / "events"
+ARCHIVE_DIR = EVENTS_DIR / "archive"
+README = REPO_ROOT / "README.md"
+MARKER_START = "<!-- EVENTS:START -->"
+MARKER_END = "<!-- EVENTS:END -->"
+DEFAULT_TZ = ZoneInfo("Europe/London")
+ARCHIVE_AGE_DAYS = 90
+
+DATE_FMT_IN = ["%Y-%m-%d %H:%M", "%Y-%m-%d"]
+DATE_FMT_OUT = "%Y-%m-%d"
+
+def parse_start(dt_str: str, tz_str: str | None):
+    tz = DEFAULT_TZ
+    if tz_str:
+        try:
+            tz = ZoneInfo(tz_str)
+        except Exception:
+            tz = DEFAULT_TZ
+    last_err = None
+    for fmt in DATE_FMT_IN:
+        try:
+            dt = datetime.strptime(dt_str, fmt)
+            return dt.replace(tzinfo=tz)  # treat naive as local to tz
+        except ValueError as e:
+            last_err = e
+    raise ValueError(f"Cannot parse start '{dt_str}': {last_err}")
+
+def load_events():
+    if not EVENTS_DIR.exists():
+        return []
+    events = []
+    for path in EVENTS_DIR.glob("*.yaml"):
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        title = data.get("title")
+        start_raw = data.get("start")
+        tz_str = data.get("timezone")
+        if not title or not start_raw:
+            continue
+        start = parse_start(str(start_raw), tz_str)
+        events.append({
+            "path": path,
+            "title": title,
+            "start": start,
+            "date_str": start.strftime(DATE_FMT_OUT),
+            "location": data.get("location", ""),
+            "link": data.get("link") or data.get("registration_link") or "",
+            "summary": data.get("summary", "") or "",
+            "id": data.get("id", path.stem),
+        })
+    return events
+
+def classify_events(events):
+    now = datetime.now(DEFAULT_TZ)
+    cutoff = now - timedelta(days=ARCHIVE_AGE_DAYS)
+    upcoming, past_recent, to_archive = [], [], []
+    for e in events:
+        if e["start"] >= now:
+            upcoming.append(e)
+        elif e["start"] >= cutoff:
+            past_recent.append(e)
+        else:
+            to_archive.append(e)
+    upcoming.sort(key=lambda x: x["start"])
+    past_recent.sort(key=lambda x: x["start"], reverse=True)
+    return upcoming, past_recent, to_archive
+
+def move_to_archive(items):
+    if not items:
+        return False
+    ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+    changed = False
+    for e in items:
+        src = e["path"]
+        dst = ARCHIVE_DIR / src.name
+        if not dst.exists():
+            shutil.move(str(src), str(dst))
+            changed = True
+    return changed
+
+def render_table(rows):
+    header = "| Date | Title | Location | Description | Link |\n|------|-------|----------|-------------|------|"
+    if not rows:
+        return header + "\n| – | – | – | – | – |"
+    lines = [header]
+    for e in rows:
+        desc = e["summary"].strip().replace("\n", " ")
+        link_md = f"[link]({e['link']})" if e["link"] else ""
+        lines.append(f"| {e['date_str']} | {e['title']} | {e['location']} | {desc} | {link_md} |")
+    return "\n".join(lines)
+
+def update_readme(upcoming, past_recent):
+    content = README.read_text(encoding="utf-8")
+    pattern = re.compile(rf"{re.escape(MARKER_START)}[\s\S]*?{re.escape(MARKER_END)}", re.M)
+    if not pattern.search(content):
+        raise RuntimeError("Markers not found in README.md")
+    block = (
+        f"{MARKER_START}\n\n"
+        f"### Upcoming\n\n{render_table(upcoming)}\n\n"
+        f"### Recent Past (last 90 days)\n\n{render_table(past_recent)}\n\n"
+        f"{MARKER_END}"
+    )
+    new_content = pattern.sub(block, content)
+    if new_content != content:
+        README.write_text(new_content, encoding="utf-8")
+        return True
+    return False
+
+def main():
+    events = load_events()
+    upcoming, past_recent, to_archive = classify_events(events)
+    moved = move_to_archive(to_archive)
+    updated = update_readme(upcoming, past_recent)
+    print("changes" if (moved or updated) else "nochanges")
+
+if __name__ == "__main__":
+    main()

--- a/events/template.yaml
+++ b/events/template.yaml
@@ -1,0 +1,21 @@
+# Copy this file to events/YYYY-MM-DD-short-title.yaml and edit.
+id: 
+
+# Required
+title:
+start:
+timezone: 
+location:
+
+
+# Optional but recommended
+end:
+organiser:
+audience:
+link:
+registration_link:
+contact:
+
+# Short markdown description
+summary: |
+Short abstract or blurb in one or two sentences.


### PR DESCRIPTION
create a github action workflow that automatically populates the events table with info stored in the events dir.

- create event file with template
- action will populate events table on main README
- events > 90 days will be moved to events/archive and will no longer show in table